### PR TITLE
Better error messaging for webserver

### DIFF
--- a/orion/pkg/controllers/location_controller.go
+++ b/orion/pkg/controllers/location_controller.go
@@ -10,6 +10,7 @@ import (
 func GetAllLocations(c *gin.Context) {
 	locationList, err := services.LocationService.GetAll()
 	if err != nil {
+		c.Error(err)
 		c.String(http.StatusInternalServerError, err.Error())
 	} else {
 		c.JSON(http.StatusOK, locationList)
@@ -23,6 +24,7 @@ func GetLocationById(c *gin.Context) {
 
 	location, err := services.LocationService.GetByLocationId(locId)
 	if err != nil {
+		c.Error(err)
 		c.String(http.StatusNotFound, err.Error())
 	} else {
 		c.JSON(http.StatusOK, location)
@@ -36,15 +38,17 @@ func CreateLocation(c *gin.Context) {
 	c.BindJSON(&locationJson)
 
 	if err := locationJson.Validate(); err != nil {
+		c.Error(err)
 		c.String(http.StatusBadRequest, err.Error())
 		return
 	}
 
 	err := services.LocationService.Create(locationJson)
 	if err != nil {
+		c.Error(err)
 		c.String(http.StatusInternalServerError, err.Error())
 	} else {
-		c.JSON(http.StatusOK, nil)
+		c.Status(http.StatusOK)
 	}
 	return
 }
@@ -56,15 +60,17 @@ func UpdateLocation(c *gin.Context) {
 	c.BindJSON(&locationJson)
 
 	if err := locationJson.Validate(); err != nil {
+		c.Error(err)
 		c.String(http.StatusBadRequest, err.Error())
 		return
 	}
 
 	err := services.LocationService.Update(locId, locationJson)
 	if err != nil {
+		c.Error(err)
 		c.String(http.StatusInternalServerError, err.Error())
 	} else {
-		c.JSON(http.StatusOK, nil)
+		c.Status(http.StatusOK)
 	}
 	return
 }
@@ -75,6 +81,7 @@ func DeleteLocation(c *gin.Context) {
 
 	err := services.LocationService.Delete(locId)
 	if err != nil {
+		c.Error(err)
 		c.String(http.StatusInternalServerError, err.Error())
 	} else {
 		c.Status(http.StatusOK)


### PR DESCRIPTION
Sometimes when errors occur on the backend (whether it's from a hard fail on the backend side or an invalid user input), it's hard to figure out why/where it happened.
On one hand, we want to give the webclient the error message, but at the same time, we should have some kind of console output in our webserver side. Note: In the future, we will have server-side logging, but for now we can easily use gin to expose error messages to both the webclient and to the webserver console.

Use `c.Error(...)` if there are any errors.
Use `c.String(...)` to send back an error status code (404, 500, etc.) and to expose error message to web client.

Another note: use `c.Json(...)` if we plan to return a JSON body. Use `c.Status()` if we are only giving back a status code.

This pattern should be applied on all controllers.
@mzhang2021 @tonywu315 If you read this and agree with this sentiment, please approve this PR! Thanks!